### PR TITLE
Feature: attribute "arm model override" allows overriding the arm model used

### DIFF
--- a/scripting/viewmodel_override.sp
+++ b/scripting/viewmodel_override.sp
@@ -207,21 +207,20 @@ void UpdateClientWeaponModel(int client) {
 		}
 	}
 	
-	if (bitsActiveModels & (MODEL_VIEW_ACTIVE | MODEL_OFFHAND_ACTIVE | MODEL_WORLD_ACTIVE) == 0) {
+	char armvmPath[PLATFORM_MAX_PATH];
+	if (!TF2CustAttr_GetString(weapon, "arm model override", armvmPath, sizeof(armvmPath))
+			&& bitsActiveModels & (MODEL_VIEW_ACTIVE | MODEL_OFFHAND_ACTIVE | MODEL_WORLD_ACTIVE) == 0) {
 		// we need to attach arm viewmodels if we render a new weapon viewmodel
 		// or if we have something attached to our offhand
 		// ... or if we have a new worldmodel as of the 2021-06-22 update
+		// ... or if we are using a custom arm model
 		return;
 	}
 	
-	char armvmPath[PLATFORM_MAX_PATH];
-	if (!TF2CustAttr_GetString(weapon, "arm model override", armvmPath, sizeof(armvmPath))) {
-		GetArmViewModel(client, armvmPath, sizeof(armvmPath));
-	}
-
-	if (FileExists(armvmPath, true)) {
+	if ((armvmPath[0] || GetArmViewModel(client, armvmPath, sizeof(armvmPath)))
+			&& FileExists(armvmPath, true)) {
 		// armvmPath might not be precached on the server
-		// mainly an issue with the gunslinger variation of the arm model
+		// mainly an issue with the gunslinger variation of the arm model for stock
 		PrecacheModel(armvmPath);
 		
 		int armvm = TF2_SpawnWearableViewmodel();

--- a/scripting/viewmodel_override.sp
+++ b/scripting/viewmodel_override.sp
@@ -215,7 +215,11 @@ void UpdateClientWeaponModel(int client) {
 	}
 	
 	char armvmPath[PLATFORM_MAX_PATH];
-	if (GetArmViewModel(client, armvmPath, sizeof(armvmPath))) {
+	if (!TF2CustAttr_GetString(weapon, "arm model override", armvmPath, sizeof(armvmPath))) {
+		GetArmViewModel(client, armvmPath, sizeof(armvmPath));
+	}
+
+	if (FileExists(armvmPath, true)) {
 		// armvmPath might not be precached on the server
 		// mainly an issue with the gunslinger variation of the arm model
 		PrecacheModel(armvmPath);


### PR DESCRIPTION
Unfortunately, it still seems to use the original animations of the classes arm models, but this could still be useful if you don't care about the animations and just want to override the arm model.

Here's an example of a a demoman with a sword with the attribute

```
"arm model override"				"models/weapons/c_models/c_soldier_arms.mdl"
```

![unknown](https://user-images.githubusercontent.com/4157860/145702289-c750eca9-e3d8-4cd9-a082-174f699b002a.png)

