### PR TITLE
Support Wearable weapon Override and Implement Change Killicon and Custom Weapon Logname

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ from GameBanana).  I can't help you there; that's outside the scope of this plug
 [File Precacher]: https://forums.alliedmods.net/showpost.php?p=2634602&postcount=484
 [samplemodels]: https://forums.alliedmods.net/showpost.php?p=2188941&postcount=246
 
+### Change Killicon
+
+`cba_change_killicon.smx` provides attribute: `change killicon`
+
+- **This attribute doesn't support custom killicon.**
+- Attribute value is full weapon name (e.g. `enforcer`). 
+
+### Custom Weapon Logname
+
+`cba_custom_weapon_logname.smx` provides attribute: `custom weapon logname`
+
+- Change weapon's console logname.
+- Attribute value is any string (e.g. `sledgehammer_demo`).
+
 ## Contributing
 
 Please do (but do file an issue first).  The only reason this repository is available is because

--- a/scripting/cba_change_killicon.sp
+++ b/scripting/cba_change_killicon.sp
@@ -4,7 +4,6 @@
 #pragma newdecls required
 
 #include <tf_custom_attributes>
-#include <stocksoup/var_strings>
 #include <tf2>
 #include <tf2_stocks>
 #include <sdkhooks>

--- a/scripting/cba_change_killicon.sp
+++ b/scripting/cba_change_killicon.sp
@@ -1,0 +1,111 @@
+#pragma semicolon 1
+#include <sourcemod>
+
+#pragma newdecls required
+
+#include <tf_custom_attributes>
+#include <stocksoup/var_strings>
+#include <tf2>
+#include <tf2_stocks>
+#include <sdkhooks>
+
+int g_iTheWeaponSlotIWasLastHitBy[MAXPLAYERS + 1] = {-1, ...};
+
+public void OnPluginStart()
+{
+	HookEvent("player_death", Event_PlayerDeath, EventHookMode_Pre);
+	HookEvent("object_destroyed", Event_ObjectDestroy, EventHookMode_Pre);
+}
+
+public void OnClientPutInServer(int client)
+{
+    SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamage);
+}
+
+public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+{
+	if (0 < attacker && attacker <= MaxClients)
+	{
+		g_iTheWeaponSlotIWasLastHitBy[victim] = GetSlotFromPlayerWeapon(attacker, weapon);
+	}
+	return Plugin_Continue;
+}
+
+public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadcast)
+{
+    int client = GetClientOfUserId(event.GetInt("userid"));
+    if (!IsValidClient(client))
+	{
+		return Plugin_Continue;
+	}
+    
+    int killer = GetClientOfUserId(GetEventInt(event, "attacker"));
+    if(!IsValidClient(killer))
+	{
+		return Plugin_Continue;
+	}
+    
+    int weapon = GetPlayerWeaponSlot(killer, g_iTheWeaponSlotIWasLastHitBy[client]);
+    if (IsValidEntity(weapon))
+	{
+        char attr[64];
+        if (TF2CustAttr_GetString(weapon, "change killicon", attr, sizeof(attr)))
+        {
+            event.SetString("weapon", attr);
+		}
+    }
+    
+    return Plugin_Continue;
+}
+
+public Action Event_ObjectDestroy(Event event, const char[] name, bool dontBroadcast)
+{
+    int killer=GetClientOfUserId(event.GetInt("attacker"));
+    if(!IsValidClient(killer))
+    {
+        return Plugin_Continue;
+    }
+
+    int weapon = event.GetInt("weaponid");
+    if (IsValidEntity(weapon))
+	{
+        char attr[64];
+        if (TF2CustAttr_GetString(weapon, "change killicon", attr, sizeof(attr)))
+        {
+            event.SetString("weapon", attr);
+		}
+    }
+    
+    return Plugin_Continue;
+}
+
+stock int GetSlotFromPlayerWeapon(int client, int weapon)
+{
+	if(!IsValidClient(client)) return -1;
+	
+	for (int i = 0; i <= 5; i++)
+	{
+		if (weapon == GetPlayerWeaponSlot(client, i))
+		{
+			return i;
+		}
+	}
+	return -1;
+}
+
+stock bool IsValidClient(int client, bool replaycheck=true)
+{
+	if(client<=0 || client>MaxClients)
+		return false;
+
+	if(!IsClientInGame(client))
+		return false;
+
+	if(GetEntProp(client, Prop_Send, "m_bIsCoaching"))
+		return false;
+
+	if(replaycheck && (IsClientSourceTV(client) || IsClientReplay(client)))
+		return false;
+
+	return true;
+}

--- a/scripting/cba_custom_weapon_logname.sp
+++ b/scripting/cba_custom_weapon_logname.sp
@@ -4,7 +4,6 @@
 #pragma newdecls required
 
 #include <tf_custom_attributes>
-#include <stocksoup/var_strings>
 #include <tf2>
 #include <tf2_stocks>
 #include <sdkhooks>

--- a/scripting/cba_custom_weapon_logname.sp
+++ b/scripting/cba_custom_weapon_logname.sp
@@ -1,0 +1,95 @@
+#pragma semicolon 1
+#include <sourcemod>
+
+#pragma newdecls required
+
+#include <tf_custom_attributes>
+#include <stocksoup/var_strings>
+#include <tf2>
+#include <tf2_stocks>
+#include <sdkhooks>
+
+int g_iTheWeaponSlotIWasLastHitBy[MAXPLAYERS + 1] = {-1, ...};
+
+public void OnMapStart() {	
+	HookEvent("player_death", OnPlayerDeath, EventHookMode_Pre);
+}
+
+public void OnClientPutInServer(int client)
+{
+    SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamage);
+}
+
+public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+{
+	if (0 < attacker && attacker <= MaxClients)
+	{
+		g_iTheWeaponSlotIWasLastHitBy[victim] = GetSlotFromPlayerWeapon(attacker, weapon);
+	}
+	return Plugin_Continue;
+}
+
+public Action OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
+{
+	int client = GetClientOfUserId(event.GetInt("userid"));
+	if (!IsValidClient(client))
+	{
+		return Plugin_Continue;
+	}
+
+	int iKiller = GetClientOfUserId(event.GetInt("attacker"));
+	
+	if (!IsValidClient(iKiller))
+    {
+        return Plugin_Continue;
+    }
+	
+	int weapon = GetPlayerWeaponSlot(iKiller, g_iTheWeaponSlotIWasLastHitBy[client]);
+
+	if (IsValidEntity(weapon))
+	{
+		char WeaponLogClassname[64];
+		TF2CustAttr_GetString(weapon, "custom weapon logname", WeaponLogClassname, sizeof(WeaponLogClassname));
+		if (TF2CustAttr_GetString(weapon, "custom weapon logname", WeaponLogClassname, sizeof(WeaponLogClassname)))
+		{
+			SetEventString(event, "weapon_logclassname", WeaponLogClassname);
+		}
+	}
+
+	if (GetEventInt(event, "death_flags") & TF_DEATHFLAG_DEADRINGER) return Plugin_Continue;
+
+	g_iTheWeaponSlotIWasLastHitBy[client] = -1;
+
+	return Plugin_Continue;
+}
+
+stock int GetSlotFromPlayerWeapon(int client, int weapon)
+{
+	if(!IsValidClient(client)) return -1;
+	
+	for (int i = 0; i <= 5; i++)
+	{
+		if (weapon == GetPlayerWeaponSlot(client, i))
+		{
+			return i;
+		}
+	}
+	return -1;
+}
+
+stock bool IsValidClient(int client, bool replaycheck=true)
+{
+	if(client<=0 || client>MaxClients)
+		return false;
+
+	if(!IsClientInGame(client))
+		return false;
+
+	if(GetEntProp(client, Prop_Send, "m_bIsCoaching"))
+		return false;
+
+	if(replaycheck && (IsClientSourceTV(client) || IsClientReplay(client)))
+		return false;
+
+	return true;
+}

--- a/scripting/viewmodel_override.sp
+++ b/scripting/viewmodel_override.sp
@@ -284,6 +284,18 @@ void UpdateClientWeaponModel(int client) {
 		}
 	}
 
+	if (TF2_GetPlayerClass(client) == TFClass_Soldier) {
+		// for mantread and gunboats..
+		int boots = TF2Util_GetPlayerLoadoutEntity(client, 1);
+		char bm[PLATFORM_MAX_PATH];
+		if (IsValidEntity(boots) && TF2Util_IsEntityWearable(boots)
+				&& TF2CustAttr_GetString(boots, "clientmodel override", bm, sizeof(bm))
+				&& FileExistsAndLog(bm, true)) {
+			PrecacheModelAndLog(bm);
+			SetEntityModel(boots, bm);
+		}
+	}
+
 	char armvmPath[PLATFORM_MAX_PATH];
 	if (!TF2CustAttr_GetString(weapon, "arm model override", armvmPath, sizeof(armvmPath))
 			&& bitsActiveModels & (MODEL_VIEW_ACTIVE | MODEL_OFFHAND_ACTIVE | MODEL_WORLD_ACTIVE) == 0) {

--- a/scripting/viewmodel_override.sp
+++ b/scripting/viewmodel_override.sp
@@ -136,7 +136,7 @@ void OnWeaponSwitchPost(int client, int weapon) {
 	if (!g_bIgnoreWeaponSwitch[client]) {
 		UpdateClientWeaponModel(client);
 	}
- }
+}
 
 /**
  * Called on weapon switch.  Detaches any old viewmodel overrides and attaches replacements.

--- a/scripting/viewmodel_override.sp
+++ b/scripting/viewmodel_override.sp
@@ -210,8 +210,17 @@ void UpdateClientWeaponModel(int client) {
 				bitsActiveModels |= MODEL_OFFHAND_ACTIVE;
 			}
 		}
+
+		int boots = TF2Util_GetPlayerLoadoutEntity(client, 0);
+		char bm[PLATFORM_MAX_PATH];
+		if (IsValidEntity(boots) && TF2Util_IsEntityWearable(boots)
+				&& TF2CustAttr_GetString(boots, "clientmodel override", bm, sizeof(bm))
+				&& FileExistsAndLog(bm, true)) {
+			PrecacheModelAndLog(bm);
+			SetEntityModel(boots, bm);
+		}
 	}
-	
+
 	char armvmPath[PLATFORM_MAX_PATH];
 	if (!TF2CustAttr_GetString(weapon, "arm model override", armvmPath, sizeof(armvmPath))
 			&& bitsActiveModels & (MODEL_VIEW_ACTIVE | MODEL_OFFHAND_ACTIVE | MODEL_WORLD_ACTIVE) == 0) {


### PR DESCRIPTION
I made this for the issue #11.
also I made `change killicon` and `custom weapon logname` attribute for core attribute implementations.

> To keep the responsibilities of the core plugin to a minimum, a number of properties that were previously integral to CW2 / CW3 are delegated to attribute-implementing plugins in CWX.
>
> This includes:
>
> killfeed / log name
> weapon model (view / world)
> clip / ammo settings

here is some screenshots.
![image](https://user-images.githubusercontent.com/96904513/206823644-87747db5-9e15-4775-8e81-ec50b83e6147.png)
> clientmodel override on "Ali Baba's Wee Booties"

![image](https://user-images.githubusercontent.com/96904513/206824022-3cbd0b5b-2ff2-40c9-998e-e79a863e598f.png)
> custom weapon logname on ubersaw

![image](https://user-images.githubusercontent.com/96904513/206823871-373e8307-5bfa-4e65-ab2f-315bef29caa1.png)
> support hlstats

![image](https://user-images.githubusercontent.com/96904513/206823948-d7eab116-d8dd-4c49-95e1-1125e43a95f9.png)
> change killicon on ubersaw